### PR TITLE
Add API rate limiting and identity header middleware

### DIFF
--- a/backend/src/BiteRight.Web/BiteRight.Web.csproj
+++ b/backend/src/BiteRight.Web/BiteRight.Web.csproj
@@ -11,6 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
         <PackageReference Include="EFCore.NamingConventions" Version="8.0.3"/>
         <PackageReference Include="MediatR" Version="12.2.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1"/>

--- a/backend/src/BiteRight.Web/Middleware/IdentityIdHeaderMiddleware.cs
+++ b/backend/src/BiteRight.Web/Middleware/IdentityIdHeaderMiddleware.cs
@@ -1,0 +1,34 @@
+// # ==============================================================================
+// # Solution: BiteRight
+// # File: IdentityIdHeaderMiddleware.cs
+// # Author: Łukasz Sobczak
+// # Created: 29-02-2024
+// # ==============================================================================
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace BiteRight.Web.Middleware;
+
+public class IdentityIdHeaderMiddleware : IMiddleware
+{
+    public const string IdentityIdHeader = "X-Identity-Id";
+    public const string DefaultIdentityId = "anonymous";
+    public Task InvokeAsync(
+        HttpContext context,
+        RequestDelegate next
+    )
+    {
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var identityId = context.User.Identity.Name;
+            context.Request.Headers.Append(IdentityIdHeader, identityId);
+        }
+        else
+        {
+            context.Request.Headers.Append(IdentityIdHeader, DefaultIdentityId);
+        }
+
+        return next(context);
+    }
+}

--- a/backend/src/BiteRight.Web/Program.cs
+++ b/backend/src/BiteRight.Web/Program.cs
@@ -7,6 +7,7 @@
 
 #region
 
+using AspNetCoreRateLimit;
 using BiteRight.Web.Middleware;
 using BiteRight.Web.Registration;
 using Microsoft.AspNetCore.Builder;
@@ -32,6 +33,7 @@ DomainRegistrations.AddBiteRightDomain(builder.Services);
 
 var app = builder.Build();
 app.UseMiddleware<CorrelationIdMiddleware>();
+
 app.UseSerilogRequestLogging(opt =>
 {
     opt.MessageTemplate =
@@ -55,6 +57,9 @@ app.UseHttpsRedirection();
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.UseMiddleware<IdentityIdHeaderMiddleware>();
+app.UseClientRateLimiting();
 
 app.MapControllers();
 app.Run();


### PR DESCRIPTION
ASP.NET Core Rate Limiting package was added to project to control the rate of requests that clients can make to an API within a time span. The IdentityIdHeaderMiddleware was also created to append an identity ID header to each request. Further adjustments are made to enable rate limiting based on this identity ID header. This helps in preventing abuse by limiting the number of requests that a client can make, thereby improving security and stability of the application.